### PR TITLE
Add endpointUri configuration variable.

### DIFF
--- a/configuration-example.yaml
+++ b/configuration-example.yaml
@@ -43,6 +43,9 @@ authentication:
   - username: username
     password: password
 
+api:
+  endpointUri: https://api.oregonstate.edu/v1/web-api-skeleton/
+
 #
 ## Example Oracle configuration
 #

--- a/src/main/groovy/edu/oregonstate/mist/api/ApiConfiguration.groovy
+++ b/src/main/groovy/edu/oregonstate/mist/api/ApiConfiguration.groovy
@@ -1,0 +1,16 @@
+package edu.oregonstate.mist.api
+
+import com.fasterxml.jackson.annotation.JsonProperty
+import javax.validation.Valid
+import javax.validation.constraints.NotNull
+
+/**
+ * Configuration parameters common to all APIs
+ */
+class ApiConfiguration {
+    @JsonProperty('endpointUri')
+    @NotNull
+    @Valid
+    URI endpointUri
+}
+

--- a/src/main/groovy/edu/oregonstate/mist/api/Configuration.groovy
+++ b/src/main/groovy/edu/oregonstate/mist/api/Configuration.groovy
@@ -12,4 +12,9 @@ class Configuration extends io.dropwizard.Configuration {
     @NotNull
     @Valid
     List<Credentials> credentialsList
+
+    @JsonProperty('api')
+    @NotNull
+    @Valid
+    ApiConfiguration api
 }


### PR DESCRIPTION
Because our APIs are run behind a gateway proxy, their public URL is not
what dropwizard thinks it is.  Introduce a mandatory configuration
parameter which can be set to the URI of the api endpoint.  Applications
which need it can access it via configuration.api.endpointUri.
