### PR TITLE
Add common jsonapi classes to skeleton

### DIFF
--- a/src/main/groovy/edu/oregonstate/mist/api/jsonapi/ResourceObject.groovy
+++ b/src/main/groovy/edu/oregonstate/mist/api/jsonapi/ResourceObject.groovy
@@ -1,0 +1,8 @@
+package edu.oregonstate.mist.api.jsonapi
+
+class ResourceObject {
+    String id
+    String type
+    def attributes
+    def links
+}

--- a/src/main/groovy/edu/oregonstate/mist/api/jsonapi/ResultObject.groovy
+++ b/src/main/groovy/edu/oregonstate/mist/api/jsonapi/ResultObject.groovy
@@ -1,0 +1,23 @@
+package edu.oregonstate.mist.api.jsonapi
+
+class ResultObject {
+    /**
+     * Holds links to the current search and pagination links to allow the
+     * user to paginate through the results. The keys that can be expected
+     * in this map are: self, first, last, prev, and next.
+     *
+     * @optional
+     */
+    def links = [:]
+
+    /**
+     * Holds information about either a single object or a list of objects.
+     * When the request is for a list of objects, data will hold a list of
+     * ResourceObjects or an empty list.
+     * When the request is for a single object, data will hold an instance of
+     * ResourceObject.
+     *
+     * @required
+     */
+    def data
+}


### PR DESCRIPTION
CO-440

Our api standards follow jsonapi.org. These classes represent the
properties common to most of our apis.
