### PR TITLE
Ecspcs-241 Add rule to codenarc for max length of one line code

### DIFF
--- a/config/codenarc/codenarc.groovy
+++ b/config/codenarc/codenarc.groovy
@@ -78,8 +78,8 @@ ruleset {
     /* Checks the maximum length for each line of source code. Defaults is 120 characters maximum. */
     LineLength {
         description = 'Checks for number of characters, so lines that include tabs may not ' +
-                      'exceed 120 characters.'
-        length = 120
+                      'exceed 100 characters.'
+        length = 100
 
         priority = 3
     }

--- a/config/codenarc/codenarc.groovy
+++ b/config/codenarc/codenarc.groovy
@@ -74,4 +74,13 @@ ruleset {
 
     /* Check that there is at least one space after each closing brace */
     SpaceAfterClosingBrace
+
+    /* Checks the maximum length for each line of source code. Defaults is 120 maximum. */
+    LineLength {
+        description = 'Checks for number of characters, so lines that include tabs ' +
+                      'may not exceed longer than the 120 characters when viewing the file.'
+        length = 120
+
+        priority = 3
+    }
 }

--- a/config/codenarc/codenarc.groovy
+++ b/config/codenarc/codenarc.groovy
@@ -75,10 +75,10 @@ ruleset {
     /* Check that there is at least one space after each closing brace */
     SpaceAfterClosingBrace
 
-    /* Checks the maximum length for each line of source code. Defaults is 120 maximum. */
+    /* Checks the maximum length for each line of source code. Defaults is 120 characters maximum. */
     LineLength {
-        description = 'Checks for number of characters, so lines that include tabs ' +
-                      'may not exceed longer than the 120 characters when viewing the file.'
+        description = 'Checks for number of characters, so lines that include tabs may not ' +
+                      'exceed 120 characters.'
         length = 120
 
         priority = 3

--- a/src/main/groovy/edu/oregonstate/mist/api/Resource.groovy
+++ b/src/main/groovy/edu/oregonstate/mist/api/Resource.groovy
@@ -69,7 +69,8 @@ abstract class Resource {
     }
 
     /**
-     * Returns a builder for an HTTP 500 ("internal server error") response with an error message as body.
+     * Returns a builder for an HTTP 500 ("internal server error") response with an error message
+     * as body.
      *
      * @return internal server error response builder
      */


### PR DESCRIPTION
Checks for numbers of characters, so lines that include tabs may not exceed 120 characters.
