### PR TITLE
Add bin, lib and out as ignored directories to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,9 @@ build.properties
 
 # bin
 bin/
+
+# lib
+lib/
+
+# out
+out/

--- a/.gitignore
+++ b/.gitignore
@@ -18,11 +18,17 @@ configuration.yaml
 # Build Properties
 build.properties
 
-# bin
+# Driver Dependencies
 bin/
 
-# lib
+# Library Dependencies
 lib/
 
-# out
+# Output Related files
 out/
+
+# Keytool Files
+*.pem
+*.cer
+*.keystore
+*.truststore


### PR DESCRIPTION
This patch adds bin, lib and out as ignored directories to .gitignore
