### PR TITLE
Feature/co 486 build info manager example

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,9 @@ build.properties
 
 # bin
 bin/
+
+# lib
+lib/
+
+# out
+out/

--- a/.gitignore
+++ b/.gitignore
@@ -18,11 +18,17 @@ configuration.yaml
 # Build Properties
 build.properties
 
-# bin
+# Driver Dependencies
 bin/
 
-# lib
+# Library Dependencies
 lib/
 
-# out
+# Output Related files
 out/
+
+# Keytool Files
+*.pem
+*.cer
+*.keystore
+*.truststore

--- a/src/main/groovy/edu/oregonstate/mist/api/BuildInfoManager.groovy
+++ b/src/main/groovy/edu/oregonstate/mist/api/BuildInfoManager.groovy
@@ -1,0 +1,33 @@
+package edu.oregonstate.mist.api
+
+import io.dropwizard.lifecycle.Managed
+
+/**
+ * Created by georgecrary on 7/26/16.
+ */
+class BuildInfoManager implements Managed {
+    Info getInfo() {
+        info
+    }
+    private Info info = new Info()
+
+    @Override
+    public void start() throws Exception {
+        def stream = InfoResource.class.getResourceAsStream('/build.properties')
+        if (stream == null) {
+            throw new Exception("couldn't load build.properties")
+        }
+
+        def properties = new Properties()
+        properties.load(stream)
+
+        info.name = properties.get('name')
+        info.time = Long.parseLong(properties.getProperty('time'))
+        info.commit = properties.get('commit')
+        info.documentation = properties.get('documentation')
+    }
+    @Override
+    public void stop() throws Exception {
+
+    }
+}

--- a/src/main/groovy/edu/oregonstate/mist/api/InfoResource.groovy
+++ b/src/main/groovy/edu/oregonstate/mist/api/InfoResource.groovy
@@ -14,19 +14,8 @@ import javax.ws.rs.core.Response
 class InfoResource extends Resource {
     private Info info = new Info()
 
-    public InfoResource() {
-        def stream = this.class.getResourceAsStream('/build.properties')
-        if (stream == null) {
-            throw new Exception("couldn't load build.properties")
-        }
-
-        def properties = new Properties()
-        properties.load(stream)
-
-        info.name = properties.get('name')
-        info.time = Long.parseLong(properties.getProperty('time'))
-        info.commit = properties.get('commit')
-        info.documentation = properties.get('documentation')
+    public InfoResource(Info info) {
+        this.info = info
     }
 
     /**

--- a/src/main/groovy/edu/oregonstate/mist/webapiskeleton/SkeletonApplication.groovy
+++ b/src/main/groovy/edu/oregonstate/mist/webapiskeleton/SkeletonApplication.groovy
@@ -1,5 +1,6 @@
 package edu.oregonstate.mist.webapiskeleton
 
+import edu.oregonstate.mist.api.BuildInfoManager
 import edu.oregonstate.mist.api.Configuration
 import edu.oregonstate.mist.api.Resource
 import edu.oregonstate.mist.api.InfoResource
@@ -32,7 +33,11 @@ class SkeletonApplication extends Application<Configuration> {
     @Override
     public void run(Configuration configuration, Environment environment) {
         Resource.loadProperties()
-        environment.jersey().register(new InfoResource())
+
+        BuildInfoManager buildInfoManager = new BuildInfoManager()
+        environment.lifecycle().manage(buildInfoManager)
+
+        environment.jersey().register(new InfoResource(buildInfoManager.getInfo()))
         environment.jersey().register(
                 AuthFactory.binder(
                         new BasicAuthFactory<AuthenticatedUser>(


### PR DESCRIPTION
This PR adds:

CO-486, The BuildInfoManager class for loading the build properties at start time (and shutting down the DW app during start() if an exception is thrown).
CO-482, Updated .gitignore file for some dir's and key-tooling related files.
