### PR TITLE
CO-512 Record (and serve) a human-readable build time

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,6 +10,9 @@ apply plugin: 'idea'
 // https://plugins.gradle.org/plugin/com.github.johnrengelman.shadow
 apply plugin: 'com.github.johnrengelman.shadow'
 
+// https://docs.gradle.org/current/dsl/org.gradle.api.plugins.ExtraPropertiesExtension.html
+project.ext.buildTime = new Date()
+
 // https://docs.gradle.org/current/userguide/organizing_build_logic.html#sec:external_dependencies
 buildscript {
     repositories {
@@ -52,7 +55,7 @@ codenarc {
 // https://docs.gradle.org/current/dsl/org.gradle.api.tasks.bundling.Jar.html
 jar {
     baseName = project.archivesBaseName
-    appendix = System.currentTimeMillis()
+    appendix = project.ext.buildTime.getTime()
     version = 'git log -n1 --format=format:%h'.execute().getText()
     extension = 'jar'
     archiveName = "${baseName}-${appendix}-${version}.${extension}"
@@ -76,7 +79,8 @@ shadowJar {
 task writeBuildProperties << {
     Properties properties = new Properties()
     properties.setProperty('name', jar.baseName)
-    properties.setProperty('time', jar.appendix)
+    properties.setProperty('time', project.ext.buildTime.format('yyyy-MM-dd HH:mm:ssXX'))
+    properties.setProperty('unixTime', jar.appendix)
     properties.setProperty('commit', jar.version)
     properties.setProperty('documentation', 'swagger.yaml')
     FileWriter fileWriter = new FileWriter("${projectDir}/src/main/resources/build.properties")

--- a/readme.md
+++ b/readme.md
@@ -144,7 +144,7 @@ This resource returns build and runtime information:
     > --cacert doej.pem \
     > --user "username:password" \
     > https://localhost:8080/api/v0/
-    {"name":"web-api-skeleton","time":1445964601991,"commit":"f08ce22","documentation":"swagger.yaml"}
+    {"name":"web-api-skeleton","time":"2016-08-02 14:37:01-0700","unixTime":1470173821035,"commit":"e3d396e","documentation":"swagger.yaml"}
 
 NOTE: you should only specify a certificate with --cacert for local testing.
 Production servers should use a real certificate

--- a/src/main/groovy/edu/oregonstate/mist/api/BuildInfoManager.groovy
+++ b/src/main/groovy/edu/oregonstate/mist/api/BuildInfoManager.groovy
@@ -2,14 +2,12 @@ package edu.oregonstate.mist.api
 
 import io.dropwizard.lifecycle.Managed
 
-/**
- * Created by georgecrary on 7/26/16.
- */
 class BuildInfoManager implements Managed {
+    private Info info = new Info()
+
     Info getInfo() {
         info
     }
-    private Info info = new Info()
 
     @Override
     public void start() throws Exception {
@@ -22,12 +20,13 @@ class BuildInfoManager implements Managed {
         properties.load(stream)
 
         info.name = properties.get('name')
-        info.time = Long.parseLong(properties.getProperty('time'))
+        info.time = properties.get('time')
+        info.unixTime = Long.parseLong(properties.getProperty('unixTime'))
         info.commit = properties.get('commit')
         info.documentation = properties.get('documentation')
     }
+
     @Override
     public void stop() throws Exception {
-
     }
 }

--- a/src/main/groovy/edu/oregonstate/mist/api/Info.groovy
+++ b/src/main/groovy/edu/oregonstate/mist/api/Info.groovy
@@ -5,7 +5,8 @@ package edu.oregonstate.mist.api
  */
 class Info {
     String name
-    Long time
+    String time
+    Long unixTime
     String commit
     String documentation
 }

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -32,21 +32,33 @@ definitions:
     properties:
       name:
         type: string
+        description: Name of the API.
       time:
+        type: string
+        description: Build time in ISO 8601 format.
+      unixTime:
         type: integer
+        description: Build time as milliseconds since the unix epoch.
       commit:
         type: string
+        description: Git commit hash of the revision which was built.
       documentation:
         type: string
+        description: Filename of the swagger specification for the API.
   Error:
     properties:
       status:
         type: integer
+        description: HTTP status code.
       developerMessage:
         type: string
+        description: An error string aimed at developers.
       userMesage:
         type: string
+        description: An error string aimed at end users.
       code:
         type: integer
+        description: Error code.
       details:
         type: string
+        description: A link to further information about the error.


### PR DESCRIPTION
This commit replaces the time property in build.properties and the info
resource with a human-readable ISO 8601 timestamp. The unixTime property
holds the old value, the number of milliseconds since the unix epoch.
I've kept it around because it is used in the filename of the jar, so is
nice to have handy if you're trying to figure out which jar is running.
