### PR TITLE
Feature/co 487 update api to use logger

### DIFF
--- a/src/main/groovy/edu/oregonstate/mist/api/BuildInfoManager.groovy
+++ b/src/main/groovy/edu/oregonstate/mist/api/BuildInfoManager.groovy
@@ -2,9 +2,6 @@ package edu.oregonstate.mist.api
 
 import io.dropwizard.lifecycle.Managed
 
-/**
- * Created by georgecrary on 7/26/16.
- */
 class BuildInfoManager implements Managed {
     Info getInfo() {
         info

--- a/src/main/groovy/edu/oregonstate/mist/api/BuildInfoManager.groovy
+++ b/src/main/groovy/edu/oregonstate/mist/api/BuildInfoManager.groovy
@@ -15,8 +15,8 @@ class BuildInfoManager implements Managed {
      * @throws FileNotFoundException
      */
     @Override
-        def stream = InfoResource.class.getResourceAsStream('/build.properties')
     public void start() throws FileNotFoundException {
+        def stream = InfoResource.class.getResourceAsStream('/build.properties')
         if (stream == null) {
             throw new FileNotFoundException("couldn't load build.properties")
         }

--- a/src/main/groovy/edu/oregonstate/mist/api/BuildInfoManager.groovy
+++ b/src/main/groovy/edu/oregonstate/mist/api/BuildInfoManager.groovy
@@ -8,11 +8,17 @@ class BuildInfoManager implements Managed {
     }
     private Info info = new Info()
 
+    /**
+     * Loads builds.properties.
+     * DW App will halt during startup if FileNotFoundException is thrown.
+     *
+     * @throws FileNotFoundException
+     */
     @Override
-    public void start() throws Exception {
         def stream = InfoResource.class.getResourceAsStream('/build.properties')
+    public void start() throws FileNotFoundException {
         if (stream == null) {
-            throw new Exception("couldn't load build.properties")
+            throw new FileNotFoundException("couldn't load build.properties")
         }
 
         def properties = new Properties()

--- a/src/main/groovy/edu/oregonstate/mist/api/InfoResource.groovy
+++ b/src/main/groovy/edu/oregonstate/mist/api/InfoResource.groovy
@@ -30,8 +30,7 @@ class InfoResource extends Resource {
             throw new IllegalFormatPrecisionException(3)
         } catch(FileNotFoundException e) {
         }
-
-
+        
         ok(info).build()
     }
 }

--- a/src/main/groovy/edu/oregonstate/mist/api/InfoResource.groovy
+++ b/src/main/groovy/edu/oregonstate/mist/api/InfoResource.groovy
@@ -26,6 +26,12 @@ class InfoResource extends Resource {
     @GET
     @Produces(MediaType.APPLICATION_JSON)
     public Response getInfo(@Auth AuthenticatedUser authenticatedUser) {
+        try {
+            throw new IllegalFormatPrecisionException(3)
+        } catch(FileNotFoundException e) {
+        }
+
+
         ok(info).build()
     }
 }

--- a/src/main/groovy/edu/oregonstate/mist/api/InfoResource.groovy
+++ b/src/main/groovy/edu/oregonstate/mist/api/InfoResource.groovy
@@ -26,11 +26,6 @@ class InfoResource extends Resource {
     @GET
     @Produces(MediaType.APPLICATION_JSON)
     public Response getInfo(@Auth AuthenticatedUser authenticatedUser) {
-        try {
-            throw new IllegalFormatPrecisionException(3)
-        } catch(FileNotFoundException e) {
-        }
-        
         ok(info).build()
     }
 }

--- a/src/main/groovy/edu/oregonstate/mist/api/jsonapi/GenericExceptionMapper.groovy
+++ b/src/main/groovy/edu/oregonstate/mist/api/jsonapi/GenericExceptionMapper.groovy
@@ -1,5 +1,6 @@
 package edu.oregonstate.mist.api.jsonapi
 
+import edu.oregonstate.mist.api.Resource
 import edu.oregonstate.mist.api.Error
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
@@ -22,7 +23,7 @@ class GenericExceptionMapper implements ExceptionMapper<Exception> {
         Response.ResponseBuilder builder = Response.status(Response.Status.INTERNAL_SERVER_ERROR)
         builder.entity(new Error(
                 status: Response.Status.INTERNAL_SERVER_ERROR.getStatusCode(),
-                developerMessage: e.message,
+                developerMessage: "Generic exception caught and mapped.",
                 userMessage: "Generic Exception. Please contact a dev.",
                 code: Response.Status.INTERNAL_SERVER_ERROR.getStatusCode(),
                 details: "Unmapped specific exception"

--- a/src/main/groovy/edu/oregonstate/mist/api/jsonapi/GenericExceptionMapper.groovy
+++ b/src/main/groovy/edu/oregonstate/mist/api/jsonapi/GenericExceptionMapper.groovy
@@ -1,0 +1,31 @@
+package edu.oregonstate.mist.api.jsonapi
+
+import edu.oregonstate.mist.api.Error
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+
+import javax.ws.rs.core.Response
+import javax.ws.rs.ext.ExceptionMapper
+import javax.ws.rs.ext.Provider
+
+/**
+ * Created by georgecrary on 8/5/16.
+ */
+@Provider
+class GenericExceptionMapper implements ExceptionMapper<Exception> {
+    Logger logger = LoggerFactory.getLogger(GenericExceptionMapper.class)
+
+    @Override
+    public Response toResponse(Exception e) {
+        logger.error("Generic exception occured and caught by GEMapper. Please map $e" ,e)
+
+        Response.ResponseBuilder builder = Response.status(Response.Status.INTERNAL_SERVER_ERROR)
+        builder.entity(new Error(
+                status: Response.Status.INTERNAL_SERVER_ERROR.getStatusCode(),
+                developerMessage: e.message,
+                userMessage: "Generic Exception. Please contact a dev.",
+                code: Response.Status.INTERNAL_SERVER_ERROR.getStatusCode(),
+                details: "Unmapped specific exception"
+        )).build()
+    }
+}

--- a/src/main/groovy/edu/oregonstate/mist/api/jsonapi/GenericExceptionMapper.groovy
+++ b/src/main/groovy/edu/oregonstate/mist/api/jsonapi/GenericExceptionMapper.groovy
@@ -9,9 +9,6 @@ import javax.ws.rs.core.Response
 import javax.ws.rs.ext.ExceptionMapper
 import javax.ws.rs.ext.Provider
 
-/**
- * Created by georgecrary on 8/5/16.
- */
 @Provider
 class GenericExceptionMapper implements ExceptionMapper<Exception> {
     Logger logger = LoggerFactory.getLogger(GenericExceptionMapper.class)

--- a/src/main/groovy/edu/oregonstate/mist/api/jsonapi/GenericExceptionMapper.groovy
+++ b/src/main/groovy/edu/oregonstate/mist/api/jsonapi/GenericExceptionMapper.groovy
@@ -15,7 +15,8 @@ class GenericExceptionMapper implements ExceptionMapper<Exception> {
 
     @Override
     public Response toResponse(Exception e) {
-        logger.error("Generic exception occured and caught by GEMapper. Please map $e" ,e)
+        logger.error("Generic exception occured and caught by GenericExceptionMapper." +
+                "Please map the exception. $e" ,e)
 
         Response.ResponseBuilder builder = Response.status(Response.Status.INTERNAL_SERVER_ERROR)
         builder.entity(new Error(

--- a/src/main/groovy/edu/oregonstate/mist/api/jsonapi/GenericExceptionMapper.groovy
+++ b/src/main/groovy/edu/oregonstate/mist/api/jsonapi/GenericExceptionMapper.groovy
@@ -23,7 +23,7 @@ class GenericExceptionMapper implements ExceptionMapper<Exception> {
                 status: Response.Status.INTERNAL_SERVER_ERROR.getStatusCode(),
                 developerMessage: "Generic exception caught and mapped.",
                 userMessage: "Generic Exception. Please contact a dev.",
-                code: Response.Status.INTERNAL_SERVER_ERROR.getStatusCode(),
+                code: Response.Status.INTERNAL_SERVER_ERROR.getStatusCode() + 1000,
                 details: "Unmapped specific exception"
         )).build()
     }

--- a/src/main/groovy/edu/oregonstate/mist/api/jsonapi/IOExceptionMapper.groovy
+++ b/src/main/groovy/edu/oregonstate/mist/api/jsonapi/IOExceptionMapper.groovy
@@ -24,7 +24,7 @@ class IOExceptionMapper implements ExceptionMapper<IOException> {
                 status: Response.Status.INTERNAL_SERVER_ERROR.getStatusCode(),
                 developerMessage: e.message,
                 userMessage: "Internal Server Error occured. IOException. Please contact a dev.",
-                code: Response.Status.INTERNAL_SERVER_ERROR.getStatusCode(),
+                code: Response.Status.INTERNAL_SERVER_ERROR.getStatusCode() + 1000,
                 details: "IOException mapped and caught"
         )).build()
     }

--- a/src/main/groovy/edu/oregonstate/mist/api/jsonapi/IOExceptionMapper.groovy
+++ b/src/main/groovy/edu/oregonstate/mist/api/jsonapi/IOExceptionMapper.groovy
@@ -1,0 +1,31 @@
+package edu.oregonstate.mist.api.jsonapi
+
+import edu.oregonstate.mist.api.Error
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+
+import javax.ws.rs.core.Response
+import javax.ws.rs.ext.ExceptionMapper
+import javax.ws.rs.ext.Provider
+
+/**
+ * Created by georgecrary on 8/4/16.
+ */
+@Provider
+class IOExceptionMapper implements ExceptionMapper<IOException> {
+    Logger logger = LoggerFactory.getLogger(IOExceptionMapper.class)
+
+    @Override
+    public Response toResponse(IOException e) {
+        logger.error("IOException occured.",e)
+
+        Response.ResponseBuilder builder = Response.status(Response.Status.INTERNAL_SERVER_ERROR)
+        builder.entity(new Error(
+                status: Response.Status.INTERNAL_SERVER_ERROR.getStatusCode(),
+                developerMessage: e.message,
+                userMessage: "Internal Server Error occured. IOException. Please contact a dev.",
+                code: Response.Status.INTERNAL_SERVER_ERROR.getStatusCode(),
+                details: "IOException mapped and caught"
+        )).build()
+    }
+}

--- a/src/main/groovy/edu/oregonstate/mist/webapiskeleton/SkeletonApplication.groovy
+++ b/src/main/groovy/edu/oregonstate/mist/webapiskeleton/SkeletonApplication.groovy
@@ -6,6 +6,8 @@ import edu.oregonstate.mist.api.Resource
 import edu.oregonstate.mist.api.InfoResource
 import edu.oregonstate.mist.api.AuthenticatedUser
 import edu.oregonstate.mist.api.BasicAuthenticator
+import edu.oregonstate.mist.api.jsonapi.GenericExceptionMapper
+import edu.oregonstate.mist.api.jsonapi.IOExceptionMapper
 import io.dropwizard.Application
 import io.dropwizard.setup.Bootstrap
 import io.dropwizard.setup.Environment
@@ -36,6 +38,9 @@ class SkeletonApplication extends Application<Configuration> {
 
         BuildInfoManager buildInfoManager = new BuildInfoManager()
         environment.lifecycle().manage(buildInfoManager)
+
+        environment.jersey().register(new IOExceptionMapper())
+        environment.jersey().register(new GenericExceptionMapper())
 
         environment.jersey().register(new InfoResource(buildInfoManager.getInfo()))
         environment.jersey().register(

--- a/src/main/groovy/edu/oregonstate/mist/webapiskeleton/SkeletonApplication.groovy
+++ b/src/main/groovy/edu/oregonstate/mist/webapiskeleton/SkeletonApplication.groovy
@@ -49,7 +49,7 @@ class SkeletonApplication extends Application<Configuration> {
      */
     @Override
     public void run(Configuration configuration, Environment environment) {
-        Resource.loadProperties(environment)
+        Resource.loadProperties()
         BuildInfoManager buildInfoManager = new BuildInfoManager()
 
         registerAppManagerLogic(environment, buildInfoManager)

--- a/src/main/groovy/edu/oregonstate/mist/webapiskeleton/SkeletonApplication.groovy
+++ b/src/main/groovy/edu/oregonstate/mist/webapiskeleton/SkeletonApplication.groovy
@@ -27,6 +27,21 @@ class SkeletonApplication extends Application<Configuration> {
     public void initialize(Bootstrap<Configuration> bootstrap) {}
 
     /**
+     * Registers lifecycle managers and Jersey exception mappers
+     *
+     * @param environment
+     * @param buildInfoManager
+     */
+    protected void registerAppManagerLogic(Environment environment,
+                                           BuildInfoManager buildInfoManager) {
+
+        environment.lifecycle().manage(buildInfoManager)
+
+        environment.jersey().register(new IOExceptionMapper())
+        environment.jersey().register(new GenericExceptionMapper())
+    }
+
+    /**
      * Parses command-line arguments and runs the application.
      *
      * @param configuration
@@ -34,13 +49,10 @@ class SkeletonApplication extends Application<Configuration> {
      */
     @Override
     public void run(Configuration configuration, Environment environment) {
-        Resource.loadProperties()
-
+        Resource.loadProperties(environment)
         BuildInfoManager buildInfoManager = new BuildInfoManager()
-        environment.lifecycle().manage(buildInfoManager)
 
-        environment.jersey().register(new IOExceptionMapper())
-        environment.jersey().register(new GenericExceptionMapper())
+        registerAppManagerLogic(environment, buildInfoManager)
 
         environment.jersey().register(new InfoResource(buildInfoManager.getInfo()))
         environment.jersey().register(


### PR DESCRIPTION
PR for CO-487.
This PR adds the IOExceptionMapper and GenericExceptionMapper classes and registers them to the jersey environment.

Uncaught exceptions that bubble up past the resource endpoint level (of the stack) get caught by the registered exception mappers.

*The Exception handler demo has been removed as of [5e3182e](https://github.com/osu-mist/web-api-skeleton/pull/43/commits/5e3182edf382f4d384353ae1f4d9d5ecf1b92296)
