### PR TITLE
Explicitly register LoggingExceptionMapper

### DIFF
--- a/src/main/groovy/edu/oregonstate/mist/webapiskeleton/SkeletonApplication.groovy
+++ b/src/main/groovy/edu/oregonstate/mist/webapiskeleton/SkeletonApplication.groovy
@@ -14,8 +14,10 @@ import io.dropwizard.Application
 import io.dropwizard.auth.AuthDynamicFeature
 import io.dropwizard.auth.AuthValueFactoryProvider
 import io.dropwizard.auth.basic.BasicCredentialAuthFilter
+import io.dropwizard.jersey.errors.LoggingExceptionMapper
 import io.dropwizard.setup.Bootstrap
 import io.dropwizard.setup.Environment
+import javax.ws.rs.WebApplicationException
 
 /**
  * Main application class.
@@ -45,6 +47,7 @@ class SkeletonApplication extends Application<Configuration> {
 
         environment.jersey().register(new NotFoundExceptionMapper())
         environment.jersey().register(new GenericExceptionMapper())
+        environment.jersey().register(new LoggingExceptionMapper<WebApplicationException>(){})
         environment.jersey().register(new PrettyPrintResponseFilter())
     }
 


### PR DESCRIPTION
CO-709

Dropwizard's LoggingExceptionMapper, which normally handles unexpected
exceptions, was getting overridden by our GenericExceptionMapper.
That is intended. But it turns out LoggingExceptionMapper is also
responsible for turning WebApplicationExceptions into nice error
messages with the proper HTTP status codes. So subclasses of
WebApplicationException like NotAllowedException, which should generate
a 405 Method Not Allowed response, were instead getting caught by
GenericExceptionMapper and turned into a 500 Internal Server Error.

To work around this, explicitly register
LoggingExceptionMapper\<WebApplicationException\> to the jersey
application.