### PR TITLE
Create Application class

### DIFF
--- a/src/main/groovy/edu/oregonstate/mist/api/Application.groovy
+++ b/src/main/groovy/edu/oregonstate/mist/api/Application.groovy
@@ -1,0 +1,81 @@
+package edu.oregonstate.mist.api
+
+import de.thomaskrille.dropwizard_template_config.TemplateConfigBundle
+import edu.oregonstate.mist.api.BuildInfoManager
+import edu.oregonstate.mist.api.Configuration
+import edu.oregonstate.mist.api.Resource
+import edu.oregonstate.mist.api.InfoResource
+import edu.oregonstate.mist.api.AuthenticatedUser
+import edu.oregonstate.mist.api.BasicAuthenticator
+import edu.oregonstate.mist.api.PrettyPrintResponseFilter
+import edu.oregonstate.mist.api.jsonapi.GenericExceptionMapper
+import edu.oregonstate.mist.api.jsonapi.NotFoundExceptionMapper
+import io.dropwizard.auth.AuthDynamicFeature
+import io.dropwizard.auth.AuthValueFactoryProvider
+import io.dropwizard.auth.basic.BasicCredentialAuthFilter
+import io.dropwizard.jersey.errors.LoggingExceptionMapper
+import io.dropwizard.setup.Bootstrap
+import io.dropwizard.setup.Environment
+import javax.ws.rs.WebApplicationException
+
+/**
+ * Main application base class.
+ */
+class Application<T extends Configuration> extends io.dropwizard.Application<T> {
+    /**
+     * Initializes application bootstrap.
+     *
+     * @param bootstrap
+     */
+    @Override
+    public void initialize(Bootstrap<T> bootstrap) {
+        bootstrap.addBundle(new TemplateConfigBundle())
+    }
+
+    /**
+     * Performs common application setup logic.
+     *
+     * Currently this includes loading Resource properties,
+     * registering InfoResource, starting the build info lifecycle manager,
+     * installing Jersey exception mappers, installing the pretty print filter,
+     * and registering an authentication handler.
+     *
+     * Applications should call this method at the beginning of run()
+     *
+     * @param configuration
+     * @param environment
+     */
+    protected void setup(T configuration, Environment environment) {
+        Resource.loadProperties()
+
+        BuildInfoManager buildInfoManager = new BuildInfoManager()
+        environment.lifecycle().manage(buildInfoManager)
+
+        environment.jersey().register(new NotFoundExceptionMapper())
+        environment.jersey().register(new GenericExceptionMapper())
+        environment.jersey().register(new LoggingExceptionMapper<WebApplicationException>(){})
+        environment.jersey().register(new PrettyPrintResponseFilter())
+        environment.jersey().register(new InfoResource(buildInfoManager.getInfo()))
+
+        environment.jersey().register(new AuthDynamicFeature(
+                new BasicCredentialAuthFilter.Builder<AuthenticatedUser>()
+                .setAuthenticator(new BasicAuthenticator(configuration.getCredentialsList()))
+                .setRealm(this.class.simpleName)
+                .buildAuthFilter()
+        ))
+
+        environment.jersey().register(new AuthValueFactoryProvider.Binder
+                <AuthenticatedUser>(AuthenticatedUser.class))
+    }
+
+    /**
+     * Parses command-line arguments and runs the application.
+     *
+     * @param configuration
+     * @param environment
+     */
+    @Override
+    public void run(T configuration, Environment environment) {
+        this.setup(configuration, environment)
+    }
+}

--- a/src/main/groovy/edu/oregonstate/mist/webapiskeleton/SkeletonApplication.groovy
+++ b/src/main/groovy/edu/oregonstate/mist/webapiskeleton/SkeletonApplication.groovy
@@ -1,56 +1,13 @@
 package edu.oregonstate.mist.webapiskeleton
 
-import de.thomaskrille.dropwizard_template_config.TemplateConfigBundle
-import edu.oregonstate.mist.api.BuildInfoManager
+import edu.oregonstate.mist.api.Application
 import edu.oregonstate.mist.api.Configuration
-import edu.oregonstate.mist.api.Resource
-import edu.oregonstate.mist.api.InfoResource
-import edu.oregonstate.mist.api.AuthenticatedUser
-import edu.oregonstate.mist.api.BasicAuthenticator
-import edu.oregonstate.mist.api.PrettyPrintResponseFilter
-import edu.oregonstate.mist.api.jsonapi.GenericExceptionMapper
-import edu.oregonstate.mist.api.jsonapi.NotFoundExceptionMapper
-import io.dropwizard.Application
-import io.dropwizard.auth.AuthDynamicFeature
-import io.dropwizard.auth.AuthValueFactoryProvider
-import io.dropwizard.auth.basic.BasicCredentialAuthFilter
-import io.dropwizard.jersey.errors.LoggingExceptionMapper
-import io.dropwizard.setup.Bootstrap
 import io.dropwizard.setup.Environment
-import javax.ws.rs.WebApplicationException
 
 /**
  * Main application class.
  */
 class SkeletonApplication extends Application<Configuration> {
-    /**
-     * Initializes application bootstrap.
-     *
-     * @param bootstrap
-     */
-    @Override
-    public void initialize(Bootstrap<Configuration> bootstrap) {
-        bootstrap.addBundle(new TemplateConfigBundle())
-    }
-
-    /**
-     * Registers lifecycle managers and Jersey exception mappers
-     * and container response filters
-     *
-     * @param environment
-     * @param buildInfoManager
-     */
-    protected void registerAppManagerLogic(Environment environment,
-                                           BuildInfoManager buildInfoManager) {
-
-        environment.lifecycle().manage(buildInfoManager)
-
-        environment.jersey().register(new NotFoundExceptionMapper())
-        environment.jersey().register(new GenericExceptionMapper())
-        environment.jersey().register(new LoggingExceptionMapper<WebApplicationException>(){})
-        environment.jersey().register(new PrettyPrintResponseFilter())
-    }
-
     /**
      * Parses command-line arguments and runs the application.
      *
@@ -59,19 +16,7 @@ class SkeletonApplication extends Application<Configuration> {
      */
     @Override
     public void run(Configuration configuration, Environment environment) {
-        Resource.loadProperties()
-        BuildInfoManager buildInfoManager = new BuildInfoManager()
-        registerAppManagerLogic(environment, buildInfoManager)
-
-        environment.jersey().register(new InfoResource(buildInfoManager.getInfo()))
-        environment.jersey().register(new AuthDynamicFeature(
-                new BasicCredentialAuthFilter.Builder<AuthenticatedUser>()
-                .setAuthenticator(new BasicAuthenticator(configuration.getCredentialsList()))
-                .setRealm('SkeletonApplication')
-                .buildAuthFilter()
-        ))
-        environment.jersey().register(new AuthValueFactoryProvider.Binder
-                <AuthenticatedUser>(AuthenticatedUser.class))
+        this.setup(configuration, environment)
     }
 
     /**


### PR DESCRIPTION
CO-748

We've started to accumulate a lot of common startup logic in the
SkeletonApplication class. But since each application has its own
FooApplication class, and deletes the SkeletonApplication class,
changes in SkeletonApplication are not picked up when the skeleton
is merged back into each app. The changes have to be made manually,
which in practice means they are not made at all.

Introduce a new edu.oregonstate.mist.api.Application class to act
as a base class for all our applications. The setup method performs
all the common application startup logic. Each application should call
setup at the start of their run method