### PR TITLE
Add Error constructors

### DIFF
--- a/src/main/groovy/edu/oregonstate/mist/api/Application.groovy
+++ b/src/main/groovy/edu/oregonstate/mist/api/Application.groovy
@@ -1,13 +1,6 @@
 package edu.oregonstate.mist.api
 
 import de.thomaskrille.dropwizard_template_config.TemplateConfigBundle
-import edu.oregonstate.mist.api.BuildInfoManager
-import edu.oregonstate.mist.api.Configuration
-import edu.oregonstate.mist.api.Resource
-import edu.oregonstate.mist.api.InfoResource
-import edu.oregonstate.mist.api.AuthenticatedUser
-import edu.oregonstate.mist.api.BasicAuthenticator
-import edu.oregonstate.mist.api.PrettyPrintResponseFilter
 import edu.oregonstate.mist.api.jsonapi.GenericExceptionMapper
 import edu.oregonstate.mist.api.jsonapi.NotFoundExceptionMapper
 import io.dropwizard.auth.AuthDynamicFeature
@@ -35,7 +28,7 @@ class Application<T extends Configuration> extends io.dropwizard.Application<T> 
     /**
      * Performs common application setup logic.
      *
-     * Currently this includes loading Resource properties,
+     * Currently this includes loading Error properties,
      * registering InfoResource, starting the build info lifecycle manager,
      * installing Jersey exception mappers, installing the pretty print filter,
      * and registering an authentication handler.
@@ -46,8 +39,6 @@ class Application<T extends Configuration> extends io.dropwizard.Application<T> 
      * @param environment
      */
     protected void setup(T configuration, Environment environment) {
-        Resource.loadProperties()
-
         BuildInfoManager buildInfoManager = new BuildInfoManager()
         environment.lifecycle().manage(buildInfoManager)
 

--- a/src/main/groovy/edu/oregonstate/mist/api/Error.groovy
+++ b/src/main/groovy/edu/oregonstate/mist/api/Error.groovy
@@ -1,5 +1,7 @@
 package edu.oregonstate.mist.api
 
+import com.fasterxml.jackson.annotation.JsonIgnore
+
 /**
  * Error representation class.
  */
@@ -9,4 +11,88 @@ class Error {
     String userMessage
     Integer code
     String details
+
+    @JsonIgnore
+    private static Properties prop = new Properties()
+
+    /**
+     * Static initializer to load error text
+     * from the resource.properties file.
+     */
+    static {
+        def stream = this.getResourceAsStream('resource.properties')
+        if (stream == null) {
+            throw new IOException("couldn't open resource.properties")
+        }
+        prop.load(stream)
+        stream.close()
+    }
+
+    /**
+     * Returns a new Error for a HTTP 400 ("bad request") response.
+     *
+     * @param message the error message
+     * @return error
+     */
+    static Error badRequest(String message) {
+        new Error(
+            status: 400,
+            developerMessage: message,
+            userMessage: prop.getProperty('badRequest.userMessage'),
+            code: parseInt(prop.getProperty('badRequest.code')),
+            details: prop.getProperty('badRequest.details')
+        )
+    }
+
+    /**
+     * Returns a new Error for a HTTP 404 ("not found") response.
+     *
+     * @return error
+     */
+    static Error notFound() {
+        new Error(
+            status: 404,
+            developerMessage: prop.getProperty('notFound.developerMessage'),
+            userMessage: prop.getProperty('notFound.userMessage'),
+            code: parseInt(prop.getProperty('notFound.code')),
+            details: prop.getProperty('notFound.details')
+        )
+    }
+
+    /**
+     * Returns a new Error for a HTTP 409 ("conflict") response.
+     *
+     * @return error
+     */
+    static Error conflict() {
+        new Error(
+            status: 409,
+            developerMessage: prop.getProperty('conflict.developerMessage'),
+            userMessage: prop.getProperty('conflict.userMessage'),
+            code: parseInt(prop.getProperty('conflict.code')),
+            details: prop.getProperty('conflict.details')
+        )
+    }
+
+    /**
+     * Returns a new Error for a HTTP 500 ("internal server error") response.
+     *
+     * @param message the error message
+     * @return error
+     */
+    static Error internalServerError(String message) {
+        new Error(
+            status: 500,
+            developerMessage: message,
+            userMessage: prop.getProperty('internalServerError.userMessage'),
+            code: parseInt(prop.getProperty('internalServerError.code')),
+            details: prop.getProperty('internalServerError.details')
+        )
+    }
+
+    private static Integer parseInt(String s) {
+        if (s != null) {
+            Integer.parseInt(s)
+        }
+    }
 }

--- a/src/main/groovy/edu/oregonstate/mist/api/Resource.groovy
+++ b/src/main/groovy/edu/oregonstate/mist/api/Resource.groovy
@@ -12,8 +12,6 @@ import javax.ws.rs.core.UriInfo
  * Abstract class for reusing common response messages.
  */
 abstract class Resource {
-    protected static Properties properties = new Properties()
-
     /**
      * Default page number used in pagination
      */
@@ -32,12 +30,13 @@ abstract class Resource {
      */
     private URI endpointUri
 
-    public static loadProperties() {
-        def stream = this.getResourceAsStream('resource.properties')
-        if (stream == null) {
-            throw new Exception("couldn't open resource.properties")
-        }
-        properties.load(stream)
+    /**
+     * Set the base URI used to provide JSON-API pagination links.
+     *
+     * @param endpointUri the base URI
+     */
+    void setEndpointUri(URI endpointUri) {
+        this.endpointUri = endpointUri
     }
 
     /**
@@ -47,8 +46,7 @@ abstract class Resource {
      * @return ok response builder
      */
     protected static ResponseBuilder ok(Object entity) {
-        ResponseBuilder responseBuilder = Response.ok()
-        responseBuilder.entity(entity)
+        Response.ok().entity(entity)
     }
 
     /**
@@ -58,8 +56,8 @@ abstract class Resource {
      * @return created response builder
      */
     protected static ResponseBuilder created(Object entity) {
-        ResponseBuilder responseBuilder = Response.status(Response.Status.CREATED)
-        responseBuilder.entity(entity)
+        Response.status(Response.Status.CREATED)
+                .entity(entity)
     }
 
     /**
@@ -69,14 +67,8 @@ abstract class Resource {
      * @return bad request response builder
      */
     protected static ResponseBuilder badRequest(String message) {
-        ResponseBuilder responseBuilder = Response.status(Response.Status.BAD_REQUEST)
-        responseBuilder.entity(new Error(
-                status: 400,
-                developerMessage: message,
-                userMessage: properties.get('badRequest.userMessage'),
-                code: Integer.parseInt(properties.get('badRequest.code')),
-                details: properties.get('badRequest.details')
-        ))
+        Response.status(Response.Status.BAD_REQUEST)
+                .entity(Error.badRequest(message))
     }
 
     /**
@@ -85,14 +77,8 @@ abstract class Resource {
      * @return not found response builder
      */
     protected static ResponseBuilder notFound() {
-        ResponseBuilder responseBuilder = Response.status(Response.Status.NOT_FOUND)
-        responseBuilder.entity(new Error(
-                status: 404,
-                developerMessage: properties.get('notFound.developerMessage'),
-                userMessage: properties.get('notFound.userMessage'),
-                code: Integer.parseInt(properties.get('notFound.code')),
-                details: properties.get('notFound.details')
-        ))
+        Response.status(Response.Status.NOT_FOUND)
+                .entity(Error.notFound())
     }
 
     /**
@@ -101,14 +87,8 @@ abstract class Resource {
      * @return conflict response builder
      */
     protected static ResponseBuilder conflict() {
-        ResponseBuilder responseBuilder = Response.status(Response.Status.CONFLICT)
-        responseBuilder.entity(new Error(
-                status: 409,
-                developerMessage: properties.get('conflict.developerMessage'),
-                userMessage: properties.get('conflict.userMessage'),
-                code: Integer.parseInt(properties.get('conflict.code')),
-                details: properties.get('conflict.details')
-        ))
+        Response.status(Response.Status.CONFLICT)
+                .entity(Error.conflict())
     }
 
     /**
@@ -118,18 +98,8 @@ abstract class Resource {
      * @return internal server error response builder
      */
     protected static ResponseBuilder internalServerError(String message) {
-        ResponseBuilder responseBuilder = Response.status(Response.Status.INTERNAL_SERVER_ERROR)
-        responseBuilder.entity(new Error(
-                status: 500,
-                developerMessage: message,
-                userMessage: properties.get('internalServerError.userMessage'),
-                code: Integer.parseInt(properties.get('internalServerError.code')),
-                details: properties.get('internalServerError.details')
-        ))
-    }
-
-    void setEndpointUri(URI endpointUri) {
-        this.endpointUri = endpointUri
+        Response.status(Response.Status.INTERNAL_SERVER_ERROR)
+                .entity(Error.internalServerError(message))
     }
 
     /**

--- a/src/main/groovy/edu/oregonstate/mist/api/jsonapi/GenericExceptionMapper.groovy
+++ b/src/main/groovy/edu/oregonstate/mist/api/jsonapi/GenericExceptionMapper.groovy
@@ -1,7 +1,6 @@
 package edu.oregonstate.mist.api.jsonapi
 
 import edu.oregonstate.mist.api.Resource
-import edu.oregonstate.mist.api.Error
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 


### PR DESCRIPTION
CO-706

Add static methods to the Error class to construct common Error values.
Rewrite the Resource methods in terms of the new Error methods.

Error is now responsible for loading the resource properties, which
means we can get rid of Resource.loadProperties(). Error uses a static
initializer block to load the resource properties, so there is no need
for the application to do anything to load the error text.

I considered leaving Resource.properties and Resource.loadProperties()
in place for backwards compatibility, but I'm pretty sure none of our
APIs use Resource.properties directly.