### PR TITLE
Add forbidden (403) and no content (204) responses

### DIFF
--- a/src/main/groovy/edu/oregonstate/mist/api/Error.groovy
+++ b/src/main/groovy/edu/oregonstate/mist/api/Error.groovy
@@ -45,6 +45,21 @@ class Error {
     }
 
     /**
+     * Returns a new Error for a HTTP 403 ("forbidden") response.
+     *
+     * @return error
+     */
+    static Error forbidden() {
+        new Error(
+                status: 403,
+                developerMessage: prop.getProperty('forbidden.developerMessage'),
+                userMessage: prop.getProperty('forbidden.userMessage'),
+                code: parseInt(prop.getProperty('forbidden.code')),
+                details: prop.getProperty('forbidden.details')
+        )
+    }
+
+    /**
      * Returns a new Error for a HTTP 404 ("not found") response.
      *
      * @return error

--- a/src/main/groovy/edu/oregonstate/mist/api/Resource.groovy
+++ b/src/main/groovy/edu/oregonstate/mist/api/Resource.groovy
@@ -99,6 +99,16 @@ abstract class Resource {
     }
 
     /**
+     * Returns a builder for an HTTP 403 ("forbidden") response with an error message as body.
+     *
+     * @return forbidden response builder
+     */
+    protected static ResponseBuilder forbidden() {
+        Response.status(Response.Status.FORBIDDEN)
+                .entity(Error.forbidden())
+    }
+
+    /**
      * Returns a builder for an HTTP 404 ("not found") response with an error message as body.
      *
      * @return not found response builder

--- a/src/main/groovy/edu/oregonstate/mist/api/Resource.groovy
+++ b/src/main/groovy/edu/oregonstate/mist/api/Resource.groovy
@@ -76,6 +76,15 @@ abstract class Resource {
     }
 
     /**
+     * Returns a builder for an HTTP 204 ("no content") response.
+     * @param entity
+     * @return
+     */
+    protected static ResponseBuilder noContent() {
+        Response.status(Response.Status.NO_CONTENT)
+    }
+
+    /**
      * Returns a builder for an HTTP 400 ("bad request") response with an error message as body.
      *
      * @param message

--- a/src/main/resources/edu/oregonstate/mist/api/resource.properties
+++ b/src/main/resources/edu/oregonstate/mist/api/resource.properties
@@ -5,6 +5,12 @@ badRequest.userMessage = Bad Request - the application submitted invalid data. P
 badRequest.code = 1400
 badRequest.details = https://developer.oregonstate.edu/documentation/error-reference#1400
 
+## Forbidden
+forbidden.developerMessage = Forbidden - The API call is valid, but the credentials don't have access to perform the operation.
+forbidden.userMessage = Forbidden - You do not have access to perform this operation. If this is incorrect, please contact application support.
+forbidden.code = 1403
+forbidden.details = https://developer.oregonstate.edu/documentation/error-reference#1403
+
 ## Not Found
 notFound.developerMessage = Not Found - the resource requested was not found. Check the API call.
 notFound.userMessage = Not Found - the information requested was not found. If this is incorrect, please contact application support.


### PR DESCRIPTION
Changes originally implemented in osu-events-API, but they should be coming from the skeleton.