### PR TITLE
Bug/co 1136 builders need default argument

### DIFF
--- a/src/main/groovy/edu/oregonstate/mist/api/Error.groovy
+++ b/src/main/groovy/edu/oregonstate/mist/api/Error.groovy
@@ -53,14 +53,17 @@ class Error {
      * @param message the detailed error message, may be occurence-specific
      * @return errors
      */
-    static Error forbidden(String message) {
-        new Error(
-                status: "403",
-                links: new LinkObject(about: prop.getProperty('forbidden.links')),
-                code: prop.getProperty('forbidden.code'),
-                title: prop.getProperty('forbidden.title'),
-                detail: message ?: prop.getProperty('forbidden.detail')
-        )
+    static ErrorResultObject forbidden(String message) {
+        new ErrorResultObject(
+                errors: [new Error(
+                             status: "403",
+                             links: new LinkObject(about: prop.getProperty('forbidden.links')),
+                             code: prop.getProperty('forbidden.code'),
+                             title: prop.getProperty('forbidden.title'),
+                             detail: message ?: prop.getProperty('forbidden.detail')
+                             )
+                        ]
+                )
     }
 
     /**

--- a/src/main/groovy/edu/oregonstate/mist/api/Resource.groovy
+++ b/src/main/groovy/edu/oregonstate/mist/api/Resource.groovy
@@ -90,7 +90,7 @@ abstract class Resource {
      * @param message
      * @return bad request response builder
      */
-    protected static ResponseBuilder badRequest(String message) {
+    protected static ResponseBuilder badRequest(String message='') {
         Response.status(Response.Status.BAD_REQUEST)
                 .entity(Error.badRequest(message))
     }
@@ -112,7 +112,7 @@ abstract class Resource {
      *
      * @return forbidden response builder
      */
-    protected static ResponseBuilder forbidden(String message) {
+    protected static ResponseBuilder forbidden(String message='') {
         Response.status(Response.Status.FORBIDDEN)
                 .entity(Error.forbidden(message))
     }
@@ -122,7 +122,7 @@ abstract class Resource {
      *
      * @return not found response builder
      */
-    protected static ResponseBuilder notFound(String message) {
+    protected static ResponseBuilder notFound(String message='') {
         Response.status(Response.Status.NOT_FOUND)
                 .entity(Error.notFound(message))
     }
@@ -132,7 +132,7 @@ abstract class Resource {
      *
      * @return conflict response builder
      */
-    protected static ResponseBuilder conflict(String message) {
+    protected static ResponseBuilder conflict(String message='') {
         Response.status(Response.Status.CONFLICT)
                 .entity(Error.conflict(message))
     }
@@ -143,7 +143,7 @@ abstract class Resource {
      *
      * @return internal server error response builder
      */
-    protected static ResponseBuilder internalServerError(String message) {
+    protected static ResponseBuilder internalServerError(String message='') {
         Response.status(Response.Status.INTERNAL_SERVER_ERROR)
                 .entity(Error.internalServerError(message))
     }


### PR DESCRIPTION
Before merging the Feature/co-1136-follow-json-spec branch, @jaredkosanovic and I discussed why the error response builders had a default null message.

https://github.com/osu-mist/web-api-skeleton/pull/70#discussion_r213134881

The reason those were made empty strings is that existing APIs will call these methods without passing a string. If no default argument is provided, this results in a type error. Essentially, giving these arguments a default value of an empty string makes them optional arguments. The Elvis operator treats an empty string as null, and replaces the message with the default message specified in the properties file.
https://github.com/osu-mist/web-api-skeleton/blob/8bdfdf707ec2fa7091c70425c89c45f73965da2a/src/main/groovy/edu/oregonstate/mist/api/Error.groovy#L44
